### PR TITLE
Add AWS_SECURITY_TOKEN to credentials

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -598,6 +598,7 @@ module.exports = {
             aws_access_key_id: res.Credentials.AccessKeyId,
             aws_secret_access_key: res.Credentials.SecretAccessKey,
             aws_session_token: res.Credentials.SessionToken,
+            aws_security_token: res.Credentials.SessionToken,
             aws_session_expiration: res.Credentials.Expiration.toJSON()
         });
     }


### PR DESCRIPTION
Some versions of boto don't actually support the AWS_SESSION_TOKEN and
haven't for some time. This commit writes the provided security token
into a security_token value in the ini file